### PR TITLE
Fix/harden by css selector rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @andreasnicolaou/eslint-plugin-no-classes-by-css
 
-ESLint plugin to disallow the use of `By.css` with CSS class selectors in Jasmine tests. This plugin helps enforce better practices by avoiding over-reliance on CSS classes for element selection in tests.
+ESLint plugin to disallow the use of CSS class selectors in Angular tests that call `By.css`. This plugin helps enforce better practices by avoiding over-reliance on CSS classes for element selection in tests.
 
 ![JavaScript](https://img.shields.io/badge/JS-JavaScript-f7df1e?logo=javascript&logoColor=black)
 ![GitHub contributors](https://img.shields.io/github/contributors/andreasnicolaou/eslint-plugin-no-classes-by-css)
@@ -38,28 +38,24 @@ Add the plugin to the plugins section and the rule to the rules section in your 
 ],
 "rules": {
   "@andreasnicolaou/no-classes-by-css/no-classes-by-css": [
-    "error",
-    {
-      "allowIds": true,
-      "allowTags": true
-    }
+    "error"
   ]
 }
 ```
 
 # Configuration
 
-- `allowIds`: If set to true, the plugin will allow using By.css with ID selectors (e.g., By.css('#elementId')).
-- `allowTags`: If set to true, the plugin will allow using By.css with tag selectors (e.g., By.css('button')).
+- `allowIds`: Defaults to true. If set to false, the plugin will report By.css calls with ID selectors (e.g., By.css('#elementId')).
+- `allowTags`: Defaults to true. If set to false, the plugin will report By.css calls with tag selectors (e.g., By.css('button')).
 - `disallowClasses`: By default, the plugin will disallow the use of CSS class selectors in By.css (e.g., By.css('.my-class')).
 
 # Usage
 
 This plugin enforces the following:
 
-- Disallow CSS class selectors (e.g., By.css('.my-class')) in Jasmine tests.
-- Optionally allow tag selectors (e.g., By.css('button')).
-- Optionally allow ID selectors (e.g., By.css('#my-id')).
+- Disallow CSS class selectors (e.g., By.css('.my-class'), By.css('button.primary')) in Angular tests.
+- Optionally disallow tag selectors (e.g., By.css('button')).
+- Optionally disallow ID selectors (e.g., By.css('#my-id')).
 
 To ensure proper usage, add the rule to your .eslintrc as shown above.
 
@@ -71,14 +67,10 @@ The following code will cause an ESLint error:
 const element = element(By.css('.my-class'));
 ```
 
-The correct usage would be either:
+Prefer a stable, test-oriented selector instead:
 
 ```js
-// With ID
-const element = element(By.css('#my-id'));
-
-// Or with a tag
-const element = element(By.css('button'));
+const element = element(By.css('[data-testid="submit"]'));
 ```
 
 # Autofixing
@@ -87,4 +79,4 @@ Currently, this plugin does not support automatic fixes for code violations. It 
 
 # Notice
 
-Make sure to follow best practices by using IDs or tag selectors when selecting elements for tests to ensure more stable and maintainable test code.
+Make sure to follow best practices by using stable, test-oriented attributes when selecting elements for tests.

--- a/lib/rules/no-classes-by-css.js
+++ b/lib/rules/no-classes-by-css.js
@@ -61,7 +61,7 @@ module.exports = {
             }
         }
 
-        function getStaticSelectorValue(node, callExpression) {
+        function getStaticSelectorValue(node, callExpression, visited = new Set()) {
             if (node.type === utils.AST_NODE_TYPES.Literal && typeof node.value === 'string') {
                 return node.value;
             }
@@ -88,7 +88,12 @@ module.exports = {
                 return null;
             }
 
-            return getStaticSelectorValue(declaration.init, declaration);
+            if (visited.has(declaration)) {
+                return null;
+            }
+            visited.add(declaration);
+
+            return getStaticSelectorValue(declaration.init, declaration, visited);
         }
     },
     meta: {
@@ -145,12 +150,15 @@ function inspectSelector(selector) {
         selectorParser((root) => {
             root.walkClasses(() => {
                 selectorInfo.hasClass = true;
+                return false;
             });
             root.walkTags(() => {
                 selectorInfo.hasTag = true;
+                return false;
             });
             root.walkIds(() => {
                 selectorInfo.hasId = true;
+                return false;
             });
         }).processSync(selector);
     } catch {

--- a/lib/rules/no-classes-by-css.js
+++ b/lib/rules/no-classes-by-css.js
@@ -1,120 +1,94 @@
 /**
- * @fileoverview Disallow usage of By.css with CSS classes in Jasmine tests.
+ * @fileoverview Disallow usage of CSS class selectors in Angular By.css tests.
  * @author Andreas Nicolaou
  */
 'use strict';
 const utils = require('@typescript-eslint/utils');
+const selectorParser = require('postcss-selector-parser');
+
+const DEFAULT_OPTIONS = {
+    allowIds: true,
+    allowTags: true,
+    disallowClasses: true,
+};
+
 module.exports = {
     create(context) {
-        const options = context.options[0] || {}; // Get the options passed in the ESLint config
-        const allowIds = options.allowIds || false; // Default is false if not specified
-        const allowTags = options.allowTags || false; // Default is false if not specified
-        const disallowClasses = options.disallowClasses !== undefined ? options.disallowClasses : true; // Default is true
-
-        // Track variable declarations that might contain class selectors
-        const classSelectorVariables = new Set();
-        const classSelectorArrays = new Set();
-
-        // Patterns to match class selectors, tag selectors, and ID selectors
-        const classSelectorPattern = /(?:^|[^#\w-])\s*\.\S+/;
-        const tagSelectorPattern = /^[a-z]+$/;
-        const idSelectorPattern = /^#[\w-]+$/;
+        /* istanbul ignore next -- Compatibility fallback for older ESLint versions. */
+        const sourceCode = context.sourceCode || context.getSourceCode();
+        const options = Object.assign({}, DEFAULT_OPTIONS, context.options[0]);
+        const { allowIds, allowTags, disallowClasses } = options;
 
         return {
-            VariableDeclarator(node) {
-                if (disallowClasses && node.init) {
-                    // Check for direct string assignments with class selectors
-                    if (
-                        node.init?.type === utils.AST_NODE_TYPES.Literal &&
-                        typeof node.init.value === 'string' &&
-                        classSelectorPattern.test(node.init.value)
-                    ) {
-                        if (node.id?.type === utils.AST_NODE_TYPES.Identifier) {
-                            classSelectorVariables.add(node.id.name);
-                        }
-                    }
-                    // Check for array assignments with class selectors
-                    if (node.init?.type === utils.AST_NODE_TYPES.ArrayExpression) {
-                        const hasClassSelector = node.init.elements.some(
-                            (el) =>
-                                el &&
-                                el?.type === utils.AST_NODE_TYPES.Literal &&
-                                typeof el.value === 'string' &&
-                                classSelectorPattern.test(el.value)
-                        );
-                        if (hasClassSelector && node.id?.type === utils.AST_NODE_TYPES.Identifier) {
-                            classSelectorArrays.add(node.id.name);
-                        }
-                    }
-                }
-            },
-
             CallExpression(node) {
-                // Check if the call expression is for By.css
-                if (
-                    node.callee?.type === utils.AST_NODE_TYPES.MemberExpression &&
-                    node.callee.object.name === 'By' &&
-                    node.callee.property.name === 'css' &&
-                    node.arguments.length > 0
-                ) {
-                    const arg = node.arguments[0];
-                    // Handle literal strings
-                    if (arg?.type === utils.AST_NODE_TYPES.Literal && typeof arg.value === 'string') {
-                        checkSelector(arg.value, node);
-                        return;
-                    }
-                    // Handle identifier references (variables)
-                    if (
-                        disallowClasses &&
-                        arg?.type === utils.AST_NODE_TYPES.Identifier &&
-                        classSelectorVariables.has(arg.name)
-                    ) {
-                        context.report({
-                            node,
-                            messageId: 'noClasses',
-                        });
-                        return;
-                    }
-                } else {
-                    const arrayNode = node.callee.object;
-                    if (
-                        disallowClasses &&
-                        arrayNode?.type === utils.AST_NODE_TYPES.Identifier &&
-                        classSelectorArrays.has(arrayNode.name)
-                    ) {
-                        context.report({
-                            node,
-                            messageId: 'noClasses',
-                        });
-                    }
+                if (!isByCssCall(node)) {
+                    return;
                 }
+
+                const selector = getStaticSelectorValue(node.arguments[0], node);
+                if (selector === null) {
+                    return;
+                }
+
+                checkSelector(selector, node);
             },
         };
 
         function checkSelector(selector, node) {
-            // Check for class selectors if disallowClasses is true
-            if (classSelectorPattern.test(selector) && disallowClasses) {
+            const selectorInfo = inspectSelector(selector);
+
+            if (selectorInfo.hasClass && disallowClasses) {
                 context.report({
                     node,
                     messageId: 'noClasses',
                 });
                 return;
             }
-            // Check for tag selectors if allowTags is false
-            if (!allowTags && tagSelectorPattern.test(selector)) {
+
+            if (!allowTags && selectorInfo.hasTag) {
                 context.report({
                     node,
                     messageId: 'noTags',
                 });
                 return;
             }
-            // Check for ID selectors if allowIds is false
-            if (!allowIds && idSelectorPattern.test(selector)) {
+
+            if (!allowIds && selectorInfo.hasId) {
                 context.report({
                     node,
                     messageId: 'noIds',
                 });
             }
+        }
+
+        function getStaticSelectorValue(node, callExpression) {
+            if (node.type === utils.AST_NODE_TYPES.Literal && typeof node.value === 'string') {
+                return node.value;
+            }
+
+            if (node.type === utils.AST_NODE_TYPES.TemplateLiteral && node.expressions.length === 0) {
+                return node.quasis.map((quasi) => quasi.value.cooked).join('');
+            }
+
+            if (node.type !== utils.AST_NODE_TYPES.Identifier) {
+                return null;
+            }
+
+            const scope = getScope(sourceCode, context, callExpression);
+            const variable = utils.ASTUtils.findVariable(scope, node.name);
+            const definition = variable?.defs[0];
+            const declaration = definition?.node;
+
+            if (
+                definition?.type !== 'Variable' ||
+                declaration?.type !== utils.AST_NODE_TYPES.VariableDeclarator ||
+                declaration.parent?.kind !== 'const' ||
+                declaration.init == null
+            ) {
+                return null;
+            }
+
+            return getStaticSelectorValue(declaration.init, declaration);
         }
     },
     meta: {
@@ -128,8 +102,8 @@ module.exports = {
             {
                 type: 'object',
                 properties: {
-                    allowIds: { type: 'boolean', default: false },
-                    allowTags: { type: 'boolean', default: false },
+                    allowIds: { type: 'boolean', default: true },
+                    allowTags: { type: 'boolean', default: true },
                     disallowClasses: { type: 'boolean', default: true },
                 },
                 additionalProperties: false,
@@ -137,3 +111,51 @@ module.exports = {
         ],
     },
 };
+
+function isByCssCall(node) {
+    return (
+        node.callee?.type === utils.AST_NODE_TYPES.MemberExpression &&
+        !node.callee.computed &&
+        node.callee.object?.type === utils.AST_NODE_TYPES.Identifier &&
+        node.callee.object.name === 'By' &&
+        node.callee.property?.type === utils.AST_NODE_TYPES.Identifier &&
+        node.callee.property.name === 'css' &&
+        node.arguments.length > 0
+    );
+}
+
+function getScope(sourceCode, context, node) {
+    /* istanbul ignore else -- Compatibility fallback for older ESLint versions. */
+    if (typeof sourceCode.getScope === 'function') {
+        return sourceCode.getScope(node);
+    }
+
+    /* istanbul ignore next -- Compatibility fallback for older ESLint versions. */
+    return context.getScope();
+}
+
+function inspectSelector(selector) {
+    const selectorInfo = {
+        hasClass: false,
+        hasTag: false,
+        hasId: false,
+    };
+
+    try {
+        selectorParser((root) => {
+            root.walkClasses(() => {
+                selectorInfo.hasClass = true;
+            });
+            root.walkTags(() => {
+                selectorInfo.hasTag = true;
+            });
+            root.walkIds(() => {
+                selectorInfo.hasId = true;
+            });
+        }).processSync(selector);
+    } catch {
+        return selectorInfo;
+    }
+
+    return selectorInfo;
+}

--- a/lib/rules/no-classes-by-css.test.js
+++ b/lib/rules/no-classes-by-css.test.js
@@ -37,59 +37,46 @@ function testRule(code, options = {}, expectValid = true) {
 
 describe('no-classes-by-css', () => {
     test('should allow valid cases with default settings', () => {
-        testRule('By.css("button")', { allowTags: true });
+        testRule('By.css("button")');
         testRule('By.css("[data-test=\'Hello\']")');
-        testRule('By.css("#my-id")', { allowIds: true });
-        testRule('By.css("#another-id")', { allowIds: true });
+        testRule('By.css("[data-test=\'.my-class\']")');
+        testRule('By.css("#my-id")');
+        testRule('By.css("#another-id")');
         testRule('By.css("div > span")');
         testRule('By.css("input[type=\'text\']")');
-        testRule('By.css("a.b")');
-        testRule('By.css("div")', { allowTags: true });
+        testRule('By.css("div")');
+        testRule('By.css(`button`)');
     });
 
     test('should report invalid cases with default settings', () => {
-        const messages1 = testRule('By.css("button")', {}, false);
-        expect(messages1[0].messageId).toBe('noTags');
+        const invalidSelectors = [
+            '.my-class',
+            '.another-class',
+            '.class1.class2',
+            '.nested .my-class',
+            'div .my-class',
+            '.my-class  .another-class',
+            'a.b',
+            'button.primary',
+            ':not(.hidden)',
+        ];
 
-        const messages2 = testRule('By.css("#my-id")', {}, false);
-        expect(messages2[0].messageId).toBe('noIds');
-
-        const messages3 = testRule('By.css("#another-id")', {}, false);
-        expect(messages3[0].messageId).toBe('noIds');
-
-        const messages4 = testRule('By.css("div")', {}, false);
-        expect(messages4[0].messageId).toBe('noTags');
-
-        const messages5 = testRule('By.css(".my-class")', {}, false);
-        expect(messages5[0].messageId).toBe('noClasses');
-
-        const messages6 = testRule('By.css(".another-class")', {}, false);
-        expect(messages6[0].messageId).toBe('noClasses');
-
-        const messages7 = testRule('By.css(".class1.class2")', {}, false);
-        expect(messages7[0].messageId).toBe('noClasses');
-
-        const messages8 = testRule('By.css(".nested .my-class")', {}, false);
-        expect(messages8[0].messageId).toBe('noClasses');
-
-        const messages9 = testRule('By.css("div .my-class")', {}, false);
-        expect(messages9[0].messageId).toBe('noClasses');
-
-        const messages10 = testRule('By.css(".my-class  .another-class")', {}, false);
-        expect(messages10[0].messageId).toBe('noClasses');
+        invalidSelectors.forEach((selector) => {
+            const messages = testRule(`By.css("${selector}")`, {}, false);
+            expect(messages[0].messageId).toBe('noClasses');
+        });
     });
 
     test('should allow valid cases with allowIds and allowTags options', () => {
         const options = { allowIds: true, allowTags: true, disallowClasses: true };
 
-        testRule('By.css("button")', { allowTags: true });
+        testRule('By.css("button")', options);
         testRule('By.css("[data-test=\'Hello\']")', options);
-        testRule('By.css("#my-id")', { allowIds: true });
-        testRule('By.css("#another-id")', { allowIds: true });
+        testRule('By.css("#my-id")', options);
+        testRule('By.css("#another-id")', options);
         testRule('By.css("div > span")', options);
         testRule('By.css("input[type=\'text\']")', options);
-        testRule('By.css("a.b")', options);
-        testRule('By.css("div")', { allowTags: true });
+        testRule('By.css("div")', options);
     });
 
     test('should still report class selectors with allowIds and allowTags options', () => {
@@ -112,46 +99,50 @@ describe('no-classes-by-css', () => {
 
         const messages6 = testRule('By.css(".my-class  .another-class")', options, false);
         expect(messages6[0].messageId).toBe('noClasses');
+
+        const messages7 = testRule('By.css("a.b")', options, false);
+        expect(messages7[0].messageId).toBe('noClasses');
     });
 
     test('should allow class selectors when disallowClasses=false', () => {
-        testRule('By.css("button")', { allowTags: true });
+        testRule('By.css("button")');
         testRule('By.css("[data-test=\'Hello\']")');
-        testRule('By.css("#my-id")', { allowIds: true });
-        testRule('By.css("#another-id")', { allowIds: true });
+        testRule('By.css("#my-id")');
+        testRule('By.css("#another-id")');
         testRule('By.css("div > span")');
         testRule('By.css("input[type=\'text\']")');
-        testRule('By.css("a.b")');
-        testRule('By.css("div")', { allowTags: true });
+        testRule('By.css("a.b")', { disallowClasses: false });
+        testRule('By.css("div")');
         testRule('By.css(".my-class")', { disallowClasses: false });
     });
 
-    test('should still report other class violations when disallowClasses=false for some', () => {
-        const messages1 = testRule('By.css(".another-class")', {}, false);
-        expect(messages1[0].messageId).toBe('noClasses');
+    test('should report tag and id selectors only when explicitly disallowed', () => {
+        const messages1 = testRule('By.css("button")', { allowTags: false }, false);
+        expect(messages1[0].messageId).toBe('noTags');
 
-        const messages2 = testRule('By.css(".class1.class2")', {}, false);
-        expect(messages2[0].messageId).toBe('noClasses');
+        const messages2 = testRule('By.css("div > span")', { allowTags: false }, false);
+        expect(messages2[0].messageId).toBe('noTags');
 
-        const messages3 = testRule('By.css(".nested .my-class")', {}, false);
-        expect(messages3[0].messageId).toBe('noClasses');
+        const messages3 = testRule('By.css("#my-id")', { allowIds: false }, false);
+        expect(messages3[0].messageId).toBe('noIds');
 
-        const messages4 = testRule('By.css("div .my-class")', {}, false);
+        const messages4 = testRule('By.css("button.primary")', { allowTags: false }, false);
         expect(messages4[0].messageId).toBe('noClasses');
-
-        const messages5 = testRule('By.css(".my-class  .another-class")', {}, false);
-        expect(messages5[0].messageId).toBe('noClasses');
     });
 
-    test('should handle variables with array and variable options', () => {
-        testRule('By.css("button");', { allowTags: true });
-        testRule('var elements = [".data", "tags"]; elements.forEach(function(e) { By.css(e); });', {
-            disallowClasses: false,
-            allowTags: true,
-        });
+    test('should handle static selector variables conservatively', () => {
+        testRule('By.css("button");');
+        testRule('const selector = "button"; By.css(selector);');
+        testRule('let selector = ".my-class"; selector = "button"; By.css(selector);');
+        testRule('const selector = ".my-class"; By.css(selector + "");');
+        testRule('By.css(selector);');
+        testRule('function getElement(selector) { By.css(selector); }');
+        testRule('By.css("[");');
+        testRule('const elements = [".data", "tags"]; elements.forEach(function(e) { By.css(e); });');
+        testRule('const elements = [".data", "tags"]; elements.forEach(function(e) { console.log(e); });');
 
         const messages1 = testRule(
-            'var sel = ".my-class"; By.css(sel);',
+            'const sel = ".my-class"; By.css(sel);',
             { disallowClasses: true, allowTags: false },
             false
         );
@@ -159,16 +150,19 @@ describe('no-classes-by-css', () => {
         expect(messages1[0].line).toBe(1);
 
         const messages2 = testRule(
-            [
-                'var elements = [".test", "div"];',
-                'elements.forEach(function(element) {',
-                '  By.css(element)',
-                '});',
-            ].join('\n'),
+            ['const selector = `button.primary`;', 'By.css(selector);'].join('\n'),
             { disallowClasses: true, allowTags: false },
             false
         );
         expect(messages2[0].messageId).toBe('noClasses');
         expect(messages2[0].line).toBe(2);
+
+        const messages3 = testRule(
+            ['const selector = ".my-class";', 'const alias = selector;', 'By.css(alias);'].join('\n'),
+            { disallowClasses: true },
+            false
+        );
+        expect(messages3[0].messageId).toBe('noClasses');
+        expect(messages3[0].line).toBe(3);
     });
 });

--- a/lib/rules/no-classes-by-css.test.js
+++ b/lib/rules/no-classes-by-css.test.js
@@ -138,6 +138,7 @@ describe('no-classes-by-css', () => {
         testRule('By.css(selector);');
         testRule('function getElement(selector) { By.css(selector); }');
         testRule('By.css("[");');
+        testRule('const a = b; const b = a; By.css(a);');
         testRule('const elements = [".data", "tags"]; elements.forEach(function(e) { By.css(e); });');
         testRule('const elements = [".data", "tags"]; elements.forEach(function(e) { console.log(e); });');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
             "version": "2.0.0",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/utils": "^8.60.1",
+                "@typescript-eslint/utils": "^8.62.0",
                 "postcss-selector-parser": "^7.1.4"
             },
             "devDependencies": {
-                "@typescript-eslint/parser": ">=8.60.1",
+                "@typescript-eslint/parser": ">=8.62.0",
                 "babel-eslint": "^10.1.0",
                 "bundlewatch": "^0.4.2",
-                "eslint": "^10.4.1",
+                "eslint": "^10.5.0",
                 "eslint-config-prettier": "^10.1.8",
                 "eslint-plugin-prettier": "^5.5.6",
                 "jest": "^30.4.2",
-                "prettier": "3.8.3",
+                "prettier": "3.8.4",
                 "typescript": ">=6.0.3"
             },
             "peerDependencies": {
@@ -1383,16 +1383,16 @@
             "dev": true
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.1.tgz",
-            "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.0.tgz",
+            "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.60.1",
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/typescript-estree": "8.60.1",
-                "@typescript-eslint/visitor-keys": "8.60.1",
+                "@typescript-eslint/scope-manager": "8.62.0",
+                "@typescript-eslint/types": "8.62.0",
+                "@typescript-eslint/typescript-estree": "8.62.0",
+                "@typescript-eslint/visitor-keys": "8.62.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1407,15 +1407,14 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/project-service": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.1.tgz",
-            "integrity": "sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==",
-            "dev": true,
+        "node_modules/@typescript-eslint/project-service": {
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.0.tgz",
+            "integrity": "sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.60.1",
-                "@typescript-eslint/types": "^8.60.1",
+                "@typescript-eslint/tsconfig-utils": "^8.62.0",
+                "@typescript-eslint/types": "^8.62.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1429,15 +1428,14 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz",
-            "integrity": "sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==",
-            "dev": true,
+        "node_modules/@typescript-eslint/scope-manager": {
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.0.tgz",
+            "integrity": "sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/visitor-keys": "8.60.1"
+                "@typescript-eslint/types": "8.62.0",
+                "@typescript-eslint/visitor-keys": "8.62.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1447,11 +1445,10 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.1.tgz",
-            "integrity": "sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==",
-            "dev": true,
+        "node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.0.tgz",
+            "integrity": "sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==",
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1464,11 +1461,10 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
-            "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
-            "dev": true,
+        "node_modules/@typescript-eslint/types": {
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+            "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1478,17 +1474,16 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.1.tgz",
-            "integrity": "sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==",
-            "dev": true,
+        "node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.0.tgz",
+            "integrity": "sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.60.1",
-                "@typescript-eslint/tsconfig-utils": "8.60.1",
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/visitor-keys": "8.60.1",
+                "@typescript-eslint/project-service": "8.62.0",
+                "@typescript-eslint/tsconfig-utils": "8.62.0",
+                "@typescript-eslint/types": "8.62.0",
+                "@typescript-eslint/visitor-keys": "8.62.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -1506,39 +1501,19 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.1.tgz",
-            "integrity": "sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "8.60.1",
-                "eslint-visitor-keys": "^5.0.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/balanced-match": {
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
             "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "18 || 20 || >=22"
             }
         },
-        "node_modules/@typescript-eslint/parser/node_modules/brace-expansion": {
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
             "version": "5.0.6",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
             "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
@@ -1547,24 +1522,10 @@
                 "node": "18 || 20 || >=22"
             }
         },
-        "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/minimatch": {
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
             "version": "10.2.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
             "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-            "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "brace-expansion": "^5.0.5"
@@ -1577,15 +1538,15 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.1.tgz",
-            "integrity": "sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg==",
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
+            "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.60.1",
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/typescript-estree": "8.60.1"
+                "@typescript-eslint/scope-manager": "8.62.0",
+                "@typescript-eslint/types": "8.62.0",
+                "@typescript-eslint/typescript-estree": "8.62.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1599,107 +1560,13 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
-        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/project-service": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.1.tgz",
-            "integrity": "sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==",
+        "node_modules/@typescript-eslint/visitor-keys": {
+            "version": "8.62.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.0.tgz",
+            "integrity": "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.60.1",
-                "@typescript-eslint/types": "^8.60.1",
-                "debug": "^4.4.3"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
-        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz",
-            "integrity": "sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==",
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/visitor-keys": "8.60.1"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.1.tgz",
-            "integrity": "sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==",
-            "license": "MIT",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
-        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
-            "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
-            "license": "MIT",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.1.tgz",
-            "integrity": "sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==",
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/project-service": "8.60.1",
-                "@typescript-eslint/tsconfig-utils": "8.60.1",
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/visitor-keys": "8.60.1",
-                "debug": "^4.4.3",
-                "minimatch": "^10.2.2",
-                "semver": "^7.7.3",
-                "tinyglobby": "^0.2.15",
-                "ts-api-utils": "^2.5.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
-        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.1.tgz",
-            "integrity": "sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==",
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "8.60.1",
+                "@typescript-eslint/types": "8.62.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -1710,28 +1577,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
-        "node_modules/@typescript-eslint/utils/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "license": "MIT",
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/@typescript-eslint/utils/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/@typescript-eslint/utils/node_modules/eslint-visitor-keys": {
+        "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
             "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
@@ -1741,21 +1587,6 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/utils/node_modules/minimatch": {
-            "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "brace-expansion": "^5.0.5"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/@ungap/structured-clone": {
@@ -2904,10 +2735,13 @@
             }
         },
         "node_modules/eslint": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.1.tgz",
-            "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
+            "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
             "license": "MIT",
+            "workspaces": [
+                "packages/*"
+            ],
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.2",
@@ -3308,6 +3142,7 @@
             "version": "6.5.0",
             "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
             "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=12.0.0"
             },
@@ -5046,9 +4881,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.8.3",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-            "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+            "version": "3.8.4",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+            "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -5666,9 +5501,10 @@
             }
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.16",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+            "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
                 "picomatch": "^4.0.4"
@@ -5690,6 +5526,7 @@
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
             "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=18.12"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@andreasnicolaou/eslint-plugin-no-classes-by-css",
-    "version": "1.8.1",
+    "version": "2.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@andreasnicolaou/eslint-plugin-no-classes-by-css",
-            "version": "1.8.1",
+            "version": "2.0.0",
             "license": "MIT",
             "dependencies": {
                 "@typescript-eslint/utils": "^8.60.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
     "name": "@andreasnicolaou/eslint-plugin-no-classes-by-css",
-    "version": "1.8.0",
+    "version": "1.8.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@andreasnicolaou/eslint-plugin-no-classes-by-css",
-            "version": "1.8.0",
+            "version": "1.8.1",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/utils": "^8.60.1"
+                "@typescript-eslint/utils": "^8.60.1",
+                "postcss-selector-parser": "^7.1.4"
             },
             "devDependencies": {
                 "@typescript-eslint/parser": ">=8.60.1",
@@ -2703,6 +2704,18 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/cssesc": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+            "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+            "license": "MIT",
+            "bin": {
+                "cssesc": "bin/cssesc"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/debug": {
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -5010,6 +5023,19 @@
                 "node": ">=8"
             }
         },
+        "node_modules/postcss-selector-parser": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+            "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+            "license": "MIT",
+            "dependencies": {
+                "cssesc": "^3.0.0",
+                "util-deprecate": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5803,6 +5829,12 @@
             "dependencies": {
                 "punycode": "^2.1.0"
             }
+        },
+        "node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+            "license": "MIT"
         },
         "node_modules/v8-to-istanbul": {
             "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@andreasnicolaou/eslint-plugin-no-classes-by-css",
-    "version": "1.8.1",
+    "version": "2.0.0",
     "description": "ESLint plugin to disallow usage of CSS class selectors in Angular By.css tests",
     "main": "index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -32,18 +32,18 @@
         ]
     },
     "devDependencies": {
-        "@typescript-eslint/parser": ">=8.60.1",
+        "@typescript-eslint/parser": ">=8.62.0",
         "babel-eslint": "^10.1.0",
         "bundlewatch": "^0.4.2",
-        "eslint": "^10.4.1",
+        "eslint": "^10.5.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.6",
         "jest": "^30.4.2",
-        "prettier": "3.8.3",
+        "prettier": "3.8.4",
         "typescript": ">=6.0.3"
     },
     "dependencies": {
-        "@typescript-eslint/utils": "^8.60.1",
+        "@typescript-eslint/utils": "^8.62.0",
         "postcss-selector-parser": "^7.1.4"
     },
     "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@andreasnicolaou/eslint-plugin-no-classes-by-css",
-    "version": "1.8.0",
-    "description": "ESLint plugin to disallow usage of By.css with CSS classes in Jasmine tests",
+    "version": "1.8.1",
+    "description": "ESLint plugin to disallow usage of CSS class selectors in Angular By.css tests",
     "main": "index.js",
     "scripts": {
         "coverage:open": "start coverage/index.html",
@@ -34,16 +34,17 @@
     "devDependencies": {
         "@typescript-eslint/parser": ">=8.60.1",
         "babel-eslint": "^10.1.0",
+        "bundlewatch": "^0.4.2",
         "eslint": "^10.4.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.6",
         "jest": "^30.4.2",
-        "bundlewatch": "^0.4.2",
         "prettier": "3.8.3",
         "typescript": ">=6.0.3"
     },
     "dependencies": {
-        "@typescript-eslint/utils": "^8.60.1"
+        "@typescript-eslint/utils": "^8.60.1",
+        "postcss-selector-parser": "^7.1.4"
     },
     "keywords": [
         "eslint",


### PR DESCRIPTION
- Parse CSS selectors instead of using regex
- Allow tag and ID selectors by default
- Add conservative static const selector handling
- Update tests and docs for Angular By.css behavior